### PR TITLE
Update Dockerfile with pre-commit fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,6 @@ RUN python3 -m pip install --no-cache-dir --quiet --upgrade azure-cli
 
 # pre-commit https://pre-commit.com/#install
 #checkov:skip=CKV2_DOCKER_4: "Ensure that certificate validation isn't disabled with the pip '--trusted-host' option"
-RUN python3 -m pip install --no-cache-dir --quiet --upgrade --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org git+https://github.com/pre-commit/pre-commit.git@v3.6.0
+RUN python3 -m pip install --no-cache-dir --quiet --upgrade pre-commit==3.6.0
 
 WORKDIR /app


### PR DESCRIPTION
Unable to run this with devpod on vscodium, fixed with changing pre-commit install instructions, now tested and working. 


Success test after change: 
[12:05:24] debug Using docker command 'docker'
[12:05:24] debug execute inject script
[12:05:24] debug Received line after pong: done
[12:05:24] debug done inject
[12:05:24] debug done injecting
[12:05:24] debug Done InjectAgentAndExecute
[12:05:24] debug done exec
[12:05:25] debug Successfully connected to container [12:05:25] debug Run outer container tunnel
[12:05:25] debug Execute SSH server command: bash -c '/usr/local/bin/devpod' helper ssh-server --track-activity --stdio --workdir '/workspaces/terraform-modules-library' --debug [12:05:25] debug Execute SSH server command: bash -c cat /var/run/devpod/result.json [12:05:25] debug Successfully parsed result at /var/run/devpod/result.json [12:05:25] debug Forward port localhost:10800:localhost:10800 [12:05:25] debug Execute SSH server command: bash -c '/usr/local/bin/devpod' agent container credentials-server --user 'ubuntu' --configure-git-helper --configure-docker-helper --forward-ports --debug [12:05:25] debug Received ping from agent
[12:05:25] debug Start credentials server
[12:05:25] debug Start watching & forwarding open ports [12:05:25] debug Wrote docker credentials helper to /usr/local/bin/docker-credential-devpod [12:05:25] debug Credentials server started on port 12049... [12:05:25] debug New connection on localhost:10800 (Total: 1) [12:05:25] debug Accepted forward: localhost:10800